### PR TITLE
align analytics graph with visualisation graph

### DIFF
--- a/app/controller/snapshot_analyse.py
+++ b/app/controller/snapshot_analyse.py
@@ -283,7 +283,7 @@ def run_analytics(snapshot_id: int):
 
     if analytics_results == {} or \
         'degree' not in analytics_results or \
-        'betweeness' not in analytics_results:
+        'betweenness' not in analytics_results:
 
         print("starting analytics")
 


### PR DESCRIPTION
- align the projected graph used for analytics with the graph used for visualisation; previously the analytics were computed on the two-hop co-authors graph, now they are computed on the single-hop graph 
- bug fix to stop analytics from running when results have been previously saved