### PR TITLE
fix bugs due to date formatting differences on the front end and back end

### DIFF
--- a/app/controller/snapshot_analyse.py
+++ b/app/controller/snapshot_analyse.py
@@ -7,7 +7,7 @@ from graphdatascience import GraphDataScience
 import json
 import threading
 
-from app.controller.graph_queries import query_graph, CoAuthorGraph
+from app.controller.graph_queries import query_graph, CoAuthorGraph, parse_dates
 from app.controller.snapshot_get import get_snapshot
 from app.helpers import remove_snapshot_metadata
 from app import neo4j_conn
@@ -19,13 +19,6 @@ class AnalyticsThreading(object):
         thread.daemon = True
         thread.start()
 
-
-# TODO
-# timeout long queries?
-# testing
-# GDS working with docker
-# problem: analytics in front-end showing as in progress when they have actually finished
-#   (only when after immediately creating the snapshot)
 
 update_degree_centrality_query = \
     """
@@ -285,6 +278,7 @@ def compute_analytics(snapshot_id: int):
 
         graph_name = "coauthors" + str(snapshot_id)
         snapshot_filters = remove_snapshot_metadata(snapshot)
+        snapshot_filters = parse_dates(snapshot_filters)
 
         # Query the graph to perform the analytics on.
         graph = query_graph(snapshot_filters)

--- a/app/controller/snapshot_analyse.py
+++ b/app/controller/snapshot_analyse.py
@@ -314,6 +314,11 @@ def compute_analytics(snapshot_id: int):
     
     except Exception as e:
         traceback.print_exc()
+        with neo4j_conn.new_session() as session:
+            session.write_transaction(_set_analytics_status, 
+                            set_analytics_status_query, 
+                            snapshot_id,
+                            status="Error")
 
 def retrieve_analytics(snapshot_id: int):
     """

--- a/app/controller/snapshot_get.py
+++ b/app/controller/snapshot_get.py
@@ -5,8 +5,8 @@ import json
 
 
 def date_handler(obj):
-    if hasattr(obj, 'isoformat'):
-        return obj.isoformat()
+    if hasattr(obj, 'date'):
+        return obj.date().isoformat()
     else:
         raise TypeError(
             "Unserializable object {} of type {}".format(obj, type(obj))


### PR DESCRIPTION
- previously the back end was returning snapshot date fields to the front end as datetime strings, however, the front end expects these to be date strings (without time.) This PR fixes this bug, with the back end now converting these into date strings.